### PR TITLE
implement "encoding/json" package interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ func NewJson(body []byte) (*Json, error)
 func (j *Json) Array() ([]interface{}, error)
     Array type asserts to an `array`
 
+func (j *Json) Bool() (bool, error)
+    Bool type asserts to `bool`
+
 func (j *Json) Bytes() ([]byte, error)
     Bytes type asserts to `[]byte`
 
@@ -74,6 +77,9 @@ func (j *Json) Int64() (int64, error)
 func (j *Json) Map() (map[string]interface{}, error)
     Map type asserts to `map`
 
+func (j *Json) MarshalJSON() ([]byte, error)
+    Implements the json.Marshaler interface.
+
 func (j *Json) MustFloat64(args ...float64) float64
     MustFloat64 guarantees the return of a `float64` (with optional default)
 
@@ -100,4 +106,7 @@ func (j *Json) MustString(args ...string) string
 
 func (j *Json) String() (string, error)
     String type asserts to `string`
+
+func (j *Json) UnmarshalJSON(p []byte) error
+    Implements the json.Unmarshaler interface.
 ```

--- a/simplejson.go
+++ b/simplejson.go
@@ -19,7 +19,7 @@ type Json struct {
 // after unmarshaling `body` bytes
 func NewJson(body []byte) (*Json, error) {
 	j := new(Json)
-	err := json.Unmarshal(body, &j.data)
+	err := j.UnmarshalJSON(body)
 	if err != nil {
 		return nil, err
 	}
@@ -28,6 +28,16 @@ func NewJson(body []byte) (*Json, error) {
 
 // Encode returns its marshaled data as `[]byte`
 func (j *Json) Encode() ([]byte, error) {
+	return j.MarshalJSON()
+}
+
+// Implements the json.Unmarshaler interface.
+func (j *Json) UnmarshalJSON(p []byte) error {
+	return json.Unmarshal(p, &j.data)
+}
+
+// Implements the json.Marshaler interface.
+func (j *Json) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&j.data)
 }
 

--- a/simplejson_test.go
+++ b/simplejson_test.go
@@ -1,6 +1,7 @@
 package simplejson
 
 import (
+	"encoding/json"
 	"github.com/bmizerany/assert"
 	"io/ioutil"
 	"log"
@@ -82,4 +83,29 @@ func TestSimplejson(t *testing.T) {
 
 	ms2 := js.Get("test").Get("missing_string").MustString("fyea")
 	assert.Equal(t, "fyea", ms2)
+}
+
+func TestStdlibInterfaces(t *testing.T) {
+	val := new(struct {
+		Name   string `json:"name"`
+		Params *Json  `json:"params"`
+	})
+	val2 := new(struct {
+		Name   string `json:"name"`
+		Params *Json  `json:"params"`
+	})
+
+	raw := `{"name":"myobject","params":{"string":"simplejson"}}`
+
+	assert.Equal(t, nil, json.Unmarshal([]byte(raw), val))
+
+	assert.Equal(t, "myobject", val.Name)
+	assert.NotEqual(t, nil, val.Params.data)
+	s, _ := val.Params.Get("string").String()
+	assert.Equal(t, "simplejson", s)
+
+	p, err := json.Marshal(val)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, nil, json.Unmarshal(p, val2))
+	assert.Equal(t, val, val2) // stable
 }


### PR DESCRIPTION
Implements interfaces for go-simplejson to play nicely with the standard library's "encoding/json" package. Allows *Json types as struct fields, map values, and slice elements to be marshaled (and unmarshaled).

Also updates README.md which was missing the `Bool()` method
