### PR TITLE
use json.Number internally, to handle both int64 and float64

### DIFF
--- a/simplejson.go
+++ b/simplejson.go
@@ -1,7 +1,6 @@
 package simplejson
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"log"
@@ -30,14 +29,6 @@ func NewJson(body []byte) (*Json, error) {
 // Encode returns its marshaled data as `[]byte`
 func (j *Json) Encode() ([]byte, error) {
 	return j.MarshalJSON()
-}
-
-// Implements the json.Unmarshaler interface.
-func (j *Json) UnmarshalJSON(p []byte) error {
-	dec := json.NewDecoder(bytes.NewReader(p))
-	dec.UseNumber()
-
-	return dec.Decode(&j.data)
 }
 
 // Implements the json.Marshaler interface.
@@ -153,33 +144,6 @@ func (j *Json) String() (string, error) {
 		return s, nil
 	}
 	return "", errors.New("type assertion to string failed")
-}
-
-// Float64 type asserts to `json.Number` then converts to `float64`
-func (j *Json) Float64() (float64, error) {
-	if n, ok := (j.data).(json.Number); ok {
-		return n.Float64()
-	}
-	return -1, errors.New("type assertion to float64 failed")
-}
-
-// Int type asserts to `json.Number` then converts to `int`
-func (j *Json) Int() (int, error) {
-	if n, ok := (j.data).(json.Number); ok {
-		i, ok := n.Int64()
-		return int(i), ok
-	}
-
-	return -1, errors.New("type assertion to float64 failed")
-}
-
-// Int type asserts to `json.Number` then converts to `int64`
-func (j *Json) Int64() (int64, error) {
-	if n, ok := (j.data).(json.Number); ok {
-		return n.Int64()
-	}
-
-	return -1, errors.New("type assertion to float64 failed")
 }
 
 // Bytes type asserts to `[]byte`

--- a/simplejson_go10.go
+++ b/simplejson_go10.go
@@ -1,0 +1,39 @@
+// +build !go1.1
+
+package simplejson
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// Implements the json.Unmarshaler interface.
+func (j *Json) UnmarshalJSON(p []byte) error {
+	return json.Unmarshal(p, &j.data)
+}
+
+// Float64 type asserts to `float64`
+func (j *Json) Float64() (float64, error) {
+	if i, ok := (j.data).(float64); ok {
+		return i, nil
+	}
+	return -1, errors.New("type assertion to float64 failed")
+}
+
+// Int type asserts to `float64` then converts to `int`
+func (j *Json) Int() (int, error) {
+	if f, ok := (j.data).(float64); ok {
+		return int(f), nil
+	}
+
+	return -1, errors.New("type assertion to float64 failed")
+}
+
+// Int type asserts to `float64` then converts to `int64`
+func (j *Json) Int64() (int64, error) {
+	if f, ok := (j.data).(float64); ok {
+		return int64(f), nil
+	}
+
+	return -1, errors.New("type assertion to float64 failed")
+}

--- a/simplejson_go10_test.go
+++ b/simplejson_go10_test.go
@@ -1,0 +1,45 @@
+// +build !go1.1
+
+package simplejson
+
+import (
+	"github.com/bmizerany/assert"
+	"io/ioutil"
+	"log"
+	"strconv"
+	"testing"
+)
+
+func TestSimplejsonGo10(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+
+	js, err := NewJson([]byte(`{ 
+		"test": { 
+			"array": [1, "2", 3],
+			"arraywithsubs": [{"subkeyone": 1},
+			{"subkeytwo": 2, "subkeythree": 3}]
+		}
+	}`))
+
+	assert.NotEqual(t, nil, js)
+	assert.Equal(t, nil, err)
+
+	arr, _ := js.Get("test").Get("array").Array()
+	assert.NotEqual(t, nil, arr)
+	for i, v := range arr {
+		var iv int
+		switch v.(type) {
+		case float64:
+			iv = int(v.(float64))
+		case string:
+			iv, _ = strconv.Atoi(v.(string))
+		}
+		assert.Equal(t, i+1, iv)
+	}
+
+	ma := js.Get("test").Get("array").MustArray()
+	assert.Equal(t, ma, []interface{}{float64(1), "2", float64(3)})
+
+	mm := js.Get("test").Get("arraywithsubs").GetIndex(0).MustMap()
+	assert.Equal(t, mm, map[string]interface{}{"subkeyone": float64(1)})
+}

--- a/simplejson_go11.go
+++ b/simplejson_go11.go
@@ -1,0 +1,44 @@
+// +build go1.1
+
+package simplejson
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+)
+
+// Implements the json.Unmarshaler interface.
+func (j *Json) UnmarshalJSON(p []byte) error {
+	dec := json.NewDecoder(bytes.NewReader(p))
+	dec.UseNumber()
+
+	return dec.Decode(&j.data)
+}
+
+// Float64 type asserts to `json.Number` then converts to `float64`
+func (j *Json) Float64() (float64, error) {
+	if n, ok := (j.data).(json.Number); ok {
+		return n.Float64()
+	}
+	return -1, errors.New("type assertion to float64 failed")
+}
+
+// Int type asserts to `json.Number` then converts to `int`
+func (j *Json) Int() (int, error) {
+	if n, ok := (j.data).(json.Number); ok {
+		i, ok := n.Int64()
+		return int(i), ok
+	}
+
+	return -1, errors.New("type assertion to float64 failed")
+}
+
+// Int type asserts to `json.Number` then converts to `int64`
+func (j *Json) Int64() (int64, error) {
+	if n, ok := (j.data).(json.Number); ok {
+		return n.Int64()
+	}
+
+	return -1, errors.New("type assertion to float64 failed")
+}

--- a/simplejson_go11_test.go
+++ b/simplejson_go11_test.go
@@ -1,0 +1,48 @@
+// +build go1.1
+
+package simplejson
+
+import (
+	"encoding/json"
+	"github.com/bmizerany/assert"
+	"io/ioutil"
+	"log"
+	"strconv"
+	"testing"
+)
+
+func TestSimplejsonGo11(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+
+	js, err := NewJson([]byte(`{ 
+		"test": { 
+			"array": [1, "2", 3],
+			"arraywithsubs": [{"subkeyone": 1},
+			{"subkeytwo": 2, "subkeythree": 3}]
+		}
+	}`))
+
+	assert.NotEqual(t, nil, js)
+	assert.Equal(t, nil, err)
+
+	arr, _ := js.Get("test").Get("array").Array()
+	assert.NotEqual(t, nil, arr)
+	for i, v := range arr {
+		var iv int
+		switch v.(type) {
+		case json.Number:
+			i64, err := v.(json.Number).Int64()
+			assert.Equal(t, nil, err)
+			iv = int(i64)
+		case string:
+			iv, _ = strconv.Atoi(v.(string))
+		}
+		assert.Equal(t, i+1, iv)
+	}
+
+	ma := js.Get("test").Get("array").MustArray()
+	assert.Equal(t, ma, []interface{}{json.Number("1"), "2", json.Number("3")})
+
+	mm := js.Get("test").Get("arraywithsubs").GetIndex(0).MustMap()
+	assert.Equal(t, mm, map[string]interface{}{"subkeyone": json.Number("1")})
+}

--- a/simplejson_test.go
+++ b/simplejson_test.go
@@ -5,7 +5,6 @@ import (
 	"github.com/bmizerany/assert"
 	"io/ioutil"
 	"log"
-	"strconv"
 	"testing"
 )
 
@@ -37,21 +36,6 @@ func TestSimplejson(t *testing.T) {
 
 	_, ok = js.CheckGet("missing_key")
 	assert.Equal(t, false, ok)
-
-	arr, _ := js.Get("test").Get("array").Array()
-	assert.NotEqual(t, nil, arr)
-	for i, v := range arr {
-		var iv int
-		switch v.(type) {
-		case json.Number:
-			i64, err := v.(json.Number).Int64()
-			assert.Equal(t, nil, err)
-			iv = int(i64)
-		case string:
-			iv, _ = strconv.Atoi(v.(string))
-		}
-		assert.Equal(t, i+1, iv)
-	}
 
 	aws := js.Get("test").Get("arraywithsubs")
 	assert.NotEqual(t, nil, aws)
@@ -87,14 +71,8 @@ func TestSimplejson(t *testing.T) {
 	ms2 := js.Get("test").Get("missing_string").MustString("fyea")
 	assert.Equal(t, "fyea", ms2)
 
-	ma := js.Get("test").Get("array").MustArray()
-	assert.Equal(t, ma, []interface{}{json.Number("1"), "2", json.Number("3")})
-
 	ma2 := js.Get("test").Get("missing_array").MustArray([]interface{}{"1", 2, "3"})
 	assert.Equal(t, ma2, []interface{}{"1", 2, "3"})
-
-	mm := js.Get("test").Get("arraywithsubs").GetIndex(0).MustMap()
-	assert.Equal(t, mm, map[string]interface{}{"subkeyone": json.Number("1")})
 
 	mm2 := js.Get("test").Get("missing_map").MustMap(map[string]interface{}{"found": false})
 	assert.Equal(t, mm2, map[string]interface{}{"found": false})


### PR DESCRIPTION
This defers the actual parsing of the text value to the numeric type
until you dereference it using the Int(), Int64() or Float64()
receiver methods.

This has the benefit that large integers (>= 1e6) are not marshaled in
floating point exponent notation, and that very large integers (>=
2^53) do not lose precision when marshaled because they were stored
internally as float64s.
