### PR TITLE
backwards compatibility for Set and json.Number

### DIFF
--- a/simplejson_go10.go
+++ b/simplejson_go10.go
@@ -25,7 +25,6 @@ func (j *Json) Int() (int, error) {
 	if f, ok := (j.data).(float64); ok {
 		return int(f), nil
 	}
-
 	return -1, errors.New("type assertion to float64 failed")
 }
 
@@ -34,6 +33,5 @@ func (j *Json) Int64() (int64, error) {
 	if f, ok := (j.data).(float64); ok {
 		return int64(f), nil
 	}
-
 	return -1, errors.New("type assertion to float64 failed")
 }

--- a/simplejson_go10_test.go
+++ b/simplejson_go10_test.go
@@ -4,15 +4,11 @@ package simplejson
 
 import (
 	"github.com/bmizerany/assert"
-	"io/ioutil"
-	"log"
 	"strconv"
 	"testing"
 )
 
 func TestSimplejsonGo10(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-
 	js, err := NewJson([]byte(`{ 
 		"test": { 
 			"array": [1, "2", 3],

--- a/simplejson_go11.go
+++ b/simplejson_go11.go
@@ -20,7 +20,10 @@ func (j *Json) Float64() (float64, error) {
 	if n, ok := (j.data).(json.Number); ok {
 		return n.Float64()
 	}
-	return -1, errors.New("type assertion to float64 failed")
+	if f, ok := (j.data).(float64); ok {
+		return f, nil
+	}
+	return -1, errors.New("type assertion to json.Number failed")
 }
 
 // Int type asserts to `json.Number` then converts to `int`
@@ -29,8 +32,10 @@ func (j *Json) Int() (int, error) {
 		i, ok := n.Int64()
 		return int(i), ok
 	}
-
-	return -1, errors.New("type assertion to float64 failed")
+	if f, ok := (j.data).(float64); ok {
+		return int(f), nil
+	}
+	return -1, errors.New("type assertion to json.Number failed")
 }
 
 // Int type asserts to `json.Number` then converts to `int64`
@@ -38,6 +43,8 @@ func (j *Json) Int64() (int64, error) {
 	if n, ok := (j.data).(json.Number); ok {
 		return n.Int64()
 	}
-
-	return -1, errors.New("type assertion to float64 failed")
+	if f, ok := (j.data).(float64); ok {
+		return int64(f), nil
+	}
+	return -1, errors.New("type assertion to json.Number failed")
 }

--- a/simplejson_go11_test.go
+++ b/simplejson_go11_test.go
@@ -5,15 +5,11 @@ package simplejson
 import (
 	"encoding/json"
 	"github.com/bmizerany/assert"
-	"io/ioutil"
-	"log"
 	"strconv"
 	"testing"
 )
 
 func TestSimplejsonGo11(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-
 	js, err := NewJson([]byte(`{ 
 		"test": { 
 			"array": [1, "2", 3],

--- a/simplejson_test.go
+++ b/simplejson_test.go
@@ -3,16 +3,12 @@ package simplejson
 import (
 	"encoding/json"
 	"github.com/bmizerany/assert"
-	"io/ioutil"
-	"log"
 	"testing"
 )
 
 func TestSimplejson(t *testing.T) {
 	var ok bool
 	var err error
-
-	log.SetOutput(ioutil.Discard)
 
 	js, err := NewJson([]byte(`{ 
 		"test": { 
@@ -89,8 +85,14 @@ func TestSimplejson(t *testing.T) {
 	gp2, _ := js.GetPath("test", "int").Int()
 	assert.Equal(t, 10, gp2)
 
-	js.Set("test", "setTest")
-	assert.Equal(t, "setTest", js.Get("test").MustString())
+	assert.Equal(t, js.Get("test").Get("bool").MustBool(), true)
+	assert.Equal(t, js.Get("test").Get("bignum").MustInt64(), int64(9223372036854775807))
+
+	js.Set("float2", 300.0)
+	assert.Equal(t, js.Get("float2").MustFloat64(), 300.0)
+
+	js.Set("test2", "setTest")
+	assert.Equal(t, "setTest", js.Get("test2").MustString())
 }
 
 func TestStdlibInterfaces(t *testing.T) {


### PR DESCRIPTION
this preserves backwards compatibility with using Set and non json.Number types (and adds some other missing tests) cc @jehiah @mikedewar
