### PR TITLE
Add MustStringArray to match StringArray()

### DIFF
--- a/simplejson.go
+++ b/simplejson.go
@@ -305,6 +305,31 @@ func (j *Json) MustString(args ...string) string {
 	return def
 }
 
+// MustStringArray guarantees the return of a `[]string` (with optional default)
+//
+// useful when you want to interate over array values in a succinct manner:
+//		for i, s := range js.Get("results").MustStringArray() {
+//			fmt.Println(i, s)
+//		}
+func (j *Json) MustStringArray(args ...[]string) []string {
+	var def []string
+
+	switch len(args) {
+	case 0:
+	case 1:
+		def = args[0]
+	default:
+		log.Panicf("MustStringArray() received too many arguments %d", len(args))
+	}
+
+	a, err := j.StringArray()
+	if err == nil {
+		return a
+	}
+
+	return def
+}
+
 // MustInt guarantees the return of an `int` (with optional default)
 //
 // useful when you explicitly want an `int` in a single value return context:

--- a/simplejson_test.go
+++ b/simplejson_test.go
@@ -72,6 +72,19 @@ func TestSimplejson(t *testing.T) {
 	ma2 := js.Get("test").Get("missing_array").MustArray([]interface{}{"1", 2, "3"})
 	assert.Equal(t, ma2, []interface{}{"1", 2, "3"})
 
+	msa := js.Get("test").Get("string_array").MustStringArray()
+	assert.Equal(t, msa[0], "asdf")
+	assert.Equal(t, msa[1], "ghjk")
+	assert.Equal(t, msa[2], "zxcv")
+
+	msa2 := js.Get("test").Get("string_array").MustStringArray([]string{"1", "2", "3"})
+	assert.Equal(t, msa2[0], "asdf")
+	assert.Equal(t, msa2[1], "ghjk")
+	assert.Equal(t, msa2[2], "zxcv")
+
+	msa3 := js.Get("test").Get("missing_array").MustStringArray([]string{"1", "2", "3"})
+	assert.Equal(t, msa3, []string{"1", "2", "3"})
+
 	mm2 := js.Get("test").Get("missing_map").MustMap(map[string]interface{}{"found": false})
 	assert.Equal(t, mm2, map[string]interface{}{"found": false})
 


### PR DESCRIPTION
There are already `StringArray()` and `MustArray()` functions, but no `MustStringArray()`. This adds it in a consistent way with the current interface.