### PR TITLE
Inner map can be pointer to map

### DIFF
--- a/simplejson.go
+++ b/simplejson.go
@@ -33,6 +33,13 @@ func New() *Json {
 	}
 }
 
+// NewFromMap returns a pointer to a new `Json` object initialized by `data`
+func NewFromMap(data map[string]interface{}) *Json {
+	return &Json{
+		data: data,
+	}
+}
+
 // Interface returns the underlying data
 func (j *Json) Interface() interface{} {
 	return j.data
@@ -175,6 +182,9 @@ func (j *Json) CheckGet(key string) (*Json, bool) {
 func (j *Json) Map() (map[string]interface{}, error) {
 	if m, ok := (j.data).(map[string]interface{}); ok {
 		return m, nil
+	}
+	if m, ok := (j.data).(*map[string]interface{}); ok {
+		return *m, nil
 	}
 	return nil, errors.New("type assertion to map[string]interface{} failed")
 }

--- a/simplejson_test.go
+++ b/simplejson_test.go
@@ -246,3 +246,10 @@ func TestPathWillOverwriteExisting(t *testing.T) {
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "bar", s)
 }
+
+func TestInnerMapCanBePointer(t *testing.T) {
+	inner := map[string]interface{}{"key": "value"}
+	data := map[string]interface{}{"key": &inner}
+	js := NewFromMap(data)
+	assert.Equal(t, "value", js.Get("key").Get("key").MustString())
+}


### PR DESCRIPTION
I'm using go-simplejson in an application for finding differences between two maps. Go-simplejson is a great tool to ease navigation through maps.
I find it useful that maps could have pointers to maps at some levels. When I found two same pointers I know that those levels are the same and don't need to recurse into to find differences. 
Helps a lot when finding differences in large similar maps.
