### PR TITLE
Implement io.Reader

### DIFF
--- a/simplejson.go
+++ b/simplejson.go
@@ -92,11 +92,14 @@ func (j *Json) Set(key string, val interface{}) {
 		return
 	}
 	m[key] = val
+	j.reader = nil // JSON changed, reset reader
 }
 
 // SetPath modifies `Json`, recursively checking/creating map keys for the supplied path,
 // and then finally writing in the value
 func (j *Json) SetPath(branch []string, val interface{}) {
+	j.reader = nil // JSON changed, reset reader
+
 	if len(branch) == 0 {
 		j.data = val
 		return
@@ -140,6 +143,7 @@ func (j *Json) Del(key string) {
 		return
 	}
 	delete(m, key)
+	j.reader = nil // JSON changed, reset reader
 }
 
 // Get returns a pointer to a new `Json` object

--- a/simplejson_test.go
+++ b/simplejson_test.go
@@ -149,6 +149,19 @@ func TestStdlibInterfaces(t *testing.T) {
 	assert.Equal(t, val, val2) // stable
 }
 
+func TestIoReader(t *testing.T) {
+	strIn := `{"name":"myobject","params":{"string":"simplejson"}}`
+	bIn := []byte(strIn)
+	jIn, _ := NewJson(bIn)
+
+	jOut, err := NewFromReader(jIn)
+	assert.Equal(t, nil, err)
+
+	bOut, err := jOut.Encode()
+	assert.Equal(t, nil, err)
+	assert.Equal(t, bOut, bIn)
+}
+
 func TestSet(t *testing.T) {
 	js, err := NewJson([]byte(`{}`))
 	assert.Equal(t, nil, err)


### PR DESCRIPTION
simplejson.Json implements the [`io.Reader`](https://golang.org/pkg/io/#Reader) interface:

```go
type Reader interface {
  Read(p []byte) (n int, err error)
}
```

##### Why?

By implementing this standard interface simplejson would play nice with the standard library and all the 3rd party packages that work with an `io.Reader`.

For example, it would allow to POST the JSON directly rather than being forced to `Encode()` and use `bytes.NewReader()`:

```go
// Currently
import ("bytes")
payloadBytes, _ := payloadJson.Encode()
req, _ := NewRequest("POST", "http://www.example.com", bytes.NewReader(payloadBytes))

// With io.Reader
req, _ := NewRequest("POST", "http://www.example.com", payloadJson)
```

##### Implementation
When starting to read the Json it encodes the data and save the bytes in the `Reader` struct.
This struct also keeps the index of the bytes read so far.
At every read the bytes are copied to the buffer argument and the index is increased.

(See [`bytes.Read()` implementation](https://golang.org/src/bytes/reader.go?s=3260:3292#L38))

The reader is reseted when `Json.data` changes

I'm far from a Go expert, so happy to receive feedback.

##### Tests
The test builds a first `*simplejson`, then a second one using `NewFromReader()`, this test would fail if `*simplejson` doesn't implement `io.Reader`.

Also, to test that the second JSON is equivalent with the original one (so `Read()` returns the correct bytes) I encode and compare them.