### PR TITLE
Update go versions to include 1.8.x and 1.9.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,8 @@ sudo: false
 language: go
 
 go:
-  - 1.2.x
-  - 1.3.x
-  - 1.4.x
-  - 1.6.x
-  - 1.7.x
+  - 1.8.x
+  - 1.9.x
   - tip
 
 os:


### PR DESCRIPTION
This updates `.travis.yml` to include Go version `1.8.x` and `1.9.x` for automated testing.