### PR TITLE
Switch out bmizerany/assert for stretchr/testify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
     - go: tip
 
 before_install:
-  - go get -v github.com/bmizerany/assert
+  - go get -v github.com/stretchr/testify
 
 script:
   - go test -v ./...

--- a/simplejson_go10_test.go
+++ b/simplejson_go10_test.go
@@ -4,7 +4,7 @@ package simplejson
 
 import (
 	"bytes"
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 	"strconv"
 	"testing"
 )

--- a/simplejson_go11_test.go
+++ b/simplejson_go11_test.go
@@ -5,7 +5,7 @@ package simplejson
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 	"strconv"
 	"testing"
 )

--- a/simplejson_test.go
+++ b/simplejson_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSimplejson(t *testing.T) {


### PR DESCRIPTION
`bmizerany/assert` has been deprecated so this PR switches it out for `stretchr/testify` instead.