### PR TITLE
enable/disable escape HTML charactors

### DIFF
--- a/simplejson.go
+++ b/simplejson.go
@@ -1,7 +1,6 @@
 package simplejson
 
 import (
-	"encoding/json"
 	"errors"
 	"log"
 )
@@ -12,7 +11,8 @@ func Version() string {
 }
 
 type Json struct {
-	data interface{}
+	data       interface{}
+	escapeHtml bool
 }
 
 // NewJson returns a pointer to a new `Json` object
@@ -41,16 +41,6 @@ func (j *Json) Interface() interface{} {
 // Encode returns its marshaled data as `[]byte`
 func (j *Json) Encode() ([]byte, error) {
 	return j.MarshalJSON()
-}
-
-// EncodePretty returns its marshaled data as `[]byte` with indentation
-func (j *Json) EncodePretty() ([]byte, error) {
-	return json.MarshalIndent(&j.data, "", "  ")
-}
-
-// Implements the json.Marshaler interface.
-func (j *Json) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&j.data)
 }
 
 // Set modifies `Json` map by `key` and `value`
@@ -120,10 +110,10 @@ func (j *Json) Get(key string) *Json {
 	m, err := j.Map()
 	if err == nil {
 		if val, ok := m[key]; ok {
-			return &Json{val}
+			return &Json{data: val, escapeHtml: j.escapeHtml}
 		}
 	}
-	return &Json{nil}
+	return &Json{data: nil, escapeHtml: j.escapeHtml}
 }
 
 // GetPath searches for the item as specified by the branch
@@ -148,10 +138,10 @@ func (j *Json) GetIndex(index int) *Json {
 	a, err := j.Array()
 	if err == nil {
 		if len(a) > index {
-			return &Json{a[index]}
+			return &Json{data: a[index], escapeHtml: j.escapeHtml}
 		}
 	}
-	return &Json{nil}
+	return &Json{data: nil, escapeHtml: j.escapeHtml}
 }
 
 // CheckGet returns a pointer to a new `Json` object and
@@ -165,7 +155,7 @@ func (j *Json) CheckGet(key string) (*Json, bool) {
 	m, err := j.Map()
 	if err == nil {
 		if val, ok := m[key]; ok {
-			return &Json{val}, true
+			return &Json{data: val, escapeHtml: j.escapeHtml}, true
 		}
 	}
 	return nil, false

--- a/simplejson_go11_test.go
+++ b/simplejson_go11_test.go
@@ -5,9 +5,10 @@ package simplejson
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewFromReader(t *testing.T) {

--- a/simplejson_go17.go
+++ b/simplejson_go17.go
@@ -1,0 +1,37 @@
+// +build go1.7 go1.8 go1.9 go1.10
+
+package simplejson
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+func (j *Json) SetHtmlEscape(escape bool) {
+	j.escapeHtml = escape
+}
+
+// EncodePretty returns its marshaled data as `[]byte` with indentation
+func (j *Json) EncodePretty() ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(j.escapeHtml)
+	enc.SetIndent("", "  ")
+	err := enc.Encode(j.data)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), err
+}
+
+// Implements the json.Marshaler interface.
+func (j *Json) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(j.escapeHtml)
+	err := enc.Encode(j.data)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), err
+}

--- a/simplejson_go17_test.go
+++ b/simplejson_go17_test.go
@@ -1,0 +1,40 @@
+// +build go1.7 go1.8 go1.9 go1.10
+
+package simplejson
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSimpleJsonNotEscapeHTML(t *testing.T) {
+	//Use New Constructor
+	buf := []byte(`{
+		"test": {
+			"array": [1, "2", 3],
+			"arraywithsubs": [
+				{"subkeyone": 1},
+				{"subkeytwo": 2, "subkeythree": 3}
+			],
+			"bignum": 9223372036854775807,
+			"uint64": 18446744073709551615,
+			"u": "a=1234&b=456&c=789"
+		}
+	}`)
+	js, err := NewJson(buf)
+
+	//Standard Test Case
+	assert.NotEqual(t, nil, js)
+	assert.Equal(t, nil, err)
+	js.SetHtmlEscape(false)
+	txt, err := js.Encode()
+	idx := bytes.Index(txt, []byte(`\u0026`))
+	assert.NotEqual(t, true, idx > 0)
+
+	js.SetHtmlEscape(true)
+	txt, err = js.Encode()
+	idx = bytes.Index(txt, []byte(`\u0026`))
+	assert.NotEqual(t, false, idx > 0)
+}

--- a/simplejson_gon17.go
+++ b/simplejson_gon17.go
@@ -1,0 +1,15 @@
+// +build !go1.7,!go1.8,!go1.9,!go1.10
+
+import (
+	"encoding/json"
+)
+
+// EncodePretty returns its marshaled data as `[]byte` with indentation
+func (j *Json) EncodePretty() ([]byte, error) {
+	return json.MarshalIndent(&j.data, "", "  ")
+}
+
+// Implements the json.Marshaler interface.
+func (j *Json) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&j.data)
+}


### PR DESCRIPTION
fix  [issue 70](https://github.com/bitly/go-simplejson/issues/70)
