### PR TITLE
update to new version of go docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ a Go package to interact with arbitrary JSON
 
 ### Documentation
 
-Visit the docs on [gopkgdoc](http://godoc.org/github.com/bitly/go-simplejson)
+Visit the docs on [Go package discovery & docs](https://pkg.go.dev/github.com/bitly/go-simplejson)


### PR DESCRIPTION
update Go docs from `https://godoc.org/github.com/bitly/go-simplejson` to `https://pkg.go.dev/github.com/bitly/go-simplejson`