### PR TITLE
Added support for Linux on power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: false
 language: go
-
+arch:
+  - amd64
+  - ppc64le
 go:
   - 1.x
 


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/ujjwalsh/go-simplejson/builds/188445179
Please have a look.

Regards,
ujjwal